### PR TITLE
add passphrase to config.yml to read encrypted private keys

### DIFF
--- a/cmd/tunnel/config.yml.sample
+++ b/cmd/tunnel/config.yml.sample
@@ -1,5 +1,7 @@
 key_files:
   - ~/.ssh/id_rsa
+  - path: ~/.ssh/id_rsa_enc
+    passphrase: secret
 gateways:
   - server: user@addr:22
     tunnels:

--- a/cmd/tunnel/main.go
+++ b/cmd/tunnel/main.go
@@ -35,7 +35,7 @@ func main() {
 	}
 	defer file.Close()
 
-	var config YamlConfig
+	var config sshtunnel.YamlConfig
 	if err := yaml.NewDecoder(file).Decode(&config); err != nil {
 		file.Close()
 		log.Fatalf("failed to decode config file: %v", err)
@@ -50,7 +50,7 @@ func main() {
 	for _, g := range config.Gateways {
 		for _, t := range g.Tunnels {
 			wg.Add(1)
-			go func(keyFiles []string, gatewayStr string, tunnelStr string) {
+			go func(keyFiles []sshtunnel.KeyFile, gatewayStr string, tunnelStr string) {
 				defer wg.Done()
 				tunnel, err := sshtunnel.NewTunnel(keyFiles, gatewayStr, tunnelStr, logger)
 				if err != nil {
@@ -66,14 +66,6 @@ func main() {
 		}
 	}
 	wg.Wait()
-}
-
-type YamlConfig struct {
-	KeyFiles []string `yaml:"key_files"`
-	Gateways []struct {
-		Server  string   `yaml:"server"`
-		Tunnels []string `yaml:"tunnels"`
-	} `yaml:"gateways"`
 }
 
 func openConfigFile() (*os.File, error) {

--- a/cmd/tunnel/main.go
+++ b/cmd/tunnel/main.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/go-yaml/yaml"
 	"github.com/li-go/sshtunnel/syscallhelper"
 
 	"github.com/li-go/sshtunnel"
@@ -35,10 +34,9 @@ func main() {
 	}
 	defer file.Close()
 
-	var config sshtunnel.YamlConfig
-	if err := yaml.NewDecoder(file).Decode(&config); err != nil {
-		file.Close()
-		log.Fatalf("failed to decode config file: %v", err)
+	config, err := sshtunnel.LoadConfigFile(file)
+	if err != nil {
+		log.Fatalf("failed to load config file: %v", err)
 	}
 
 	logger := log.New(os.Stdout, "[sshtunnel] ", log.Flags())

--- a/config.go
+++ b/config.go
@@ -1,0 +1,32 @@
+package sshtunnel
+
+type YamlConfig struct {
+	KeyFiles []KeyFile `yaml:"key_files"`
+	Gateways []struct {
+		Server  string   `yaml:"server"`
+		Tunnels []string `yaml:"tunnels"`
+	} `yaml:"gateways"`
+}
+type KeyFile struct {
+	Path       string
+	Passphrase string
+}
+
+func (f *KeyFile) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw interface{}
+	unmarshal(&raw)
+	switch raw := raw.(type) {
+	case string:
+		*f = KeyFile{
+			Path: raw,
+		}
+	case map[interface{}]interface{}:
+		path, _ := raw["path"].(string)
+		passphrase, _ := raw["passphrase"].(string)
+		*f = KeyFile{
+			Path:       path,
+			Passphrase: passphrase,
+		}
+	}
+	return nil
+}

--- a/config.go
+++ b/config.go
@@ -1,6 +1,12 @@
 package sshtunnel
 
-type YamlConfig struct {
+import (
+	"os"
+
+	"github.com/go-yaml/yaml"
+)
+
+type YAMLConfig struct {
 	KeyFiles []KeyFile `yaml:"key_files"`
 	Gateways []struct {
 		Server  string   `yaml:"server"`
@@ -29,4 +35,12 @@ func (f *KeyFile) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 	return nil
+}
+
+func LoadConfigFile(file *os.File) (*YAMLConfig, error) {
+	var config YAMLConfig
+	if err := yaml.NewDecoder(file).Decode(&config); err != nil {
+		return nil, err
+	}
+	return &config, nil
 }

--- a/tunnel.go
+++ b/tunnel.go
@@ -30,9 +30,9 @@ type tunnel struct {
 }
 
 func NewTunnel(
-	keyFiles []string,
+	keyFiles []KeyFile,
 	gatewayStr string, // user@addr:port
-	tunnelStr string,  // remoteAddr:port -> 127.0.0.1:port
+	tunnelStr string, // remoteAddr:port -> 127.0.0.1:port
 	log logger,
 ) (*tunnel, error) {
 	auth, err := parseKeyFiles(keyFiles)


### PR DESCRIPTION
Add new syntax to config.yml to read private keys encrypted with passphrases.

```
key_files:
  - path: ~/.ssh/id_rsa
    passphrase: secret
```

Previous syntax is also kept for backward compatibility and plain keys.

```
key_files:
  - ~/.ssh/id_rsa
  # same as
  - path: ~/.ssh/id_rsa
    passphrase: 
```