### PR TITLE
FIX: typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ go install github.com/li-go/sshtunnel/cmd/tunnel@latest
 ## Usage
 
 ```bash
--$ tunnel -h
+$ tunnel -h
 NAME:
    tunnel - a tool helps to do ssh forwarding
 


### PR DESCRIPTION
僕の修正で [これ](https://github.com/li-go/sshtunnel/commit/03e889420deb71857ab3142a67a958b3b834c1a7) が上書きされていたので